### PR TITLE
Fix/type order

### DIFF
--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -65,7 +65,7 @@ is actually a batch. The batch list is intended as an intermediate data type, du
 Example: [{"node": <1d-array>, "line": <1d-array>}, {"node": <1d-array>, "line": <1d-array>}]
 """
 
-Nominal = int
+NominalValue = int
 """
 Nominal values can be IDs, booleans, enums, tap pos
 
@@ -86,7 +86,7 @@ Asymmetrical values are three-phase values like p or u_measured.
 Example: (10400.0, 10500.0, 10600.0)
 """
 
-AttributeValue = Union[RealValue, Nominal, AsymValue]
+AttributeValue = Union[RealValue, NominalValue, AsymValue]
 """
 When representing a grid as a native python structure, each attribute (u_rated etc) is either a nominal value,
 a real value, or a tuple of three real values.

--- a/src/power_grid_model/data_types.py
+++ b/src/power_grid_model/data_types.py
@@ -86,14 +86,14 @@ Asymmetrical values are three-phase values like p or u_measured.
 Example: (10400.0, 10500.0, 10600.0)
 """
 
-AttributeValue = Union[Nominal, RealValue, AsymValue]
+AttributeValue = Union[RealValue, Nominal, AsymValue]
 """
 When representing a grid as a native python structure, each attribute (u_rated etc) is either a nominal value,
 a real value, or a tuple of three real values.
 
 Examples:
-    nominal: 123
     real:    10500.0
+    nominal: 123
     asym:    (10400.0, 10500.0, 10600.0)
 """
 


### PR DESCRIPTION
I've also renamed `Nominal` to `NominalValue` to be consistent with `RealValue` and `AsymValue`.
Note that this is an interface breaking change, but I feel that it is very unlikely that someone is using this type definition.

I've checked that no-one within Alliander is using is:
https://github.com/search?q=org%3AAlliander+%22Nominal%22+language%3Apython&type=code